### PR TITLE
update config for BEiT training from VQGAN

### DIFF
--- a/models/beit/base_config.json
+++ b/models/beit/base_config.json
@@ -18,8 +18,8 @@
   "tokenizer": "vqgan",
   "image_tokenizer": {
     "is_gumbel": false,
-    "is_transformer": true,
-    "image_vocab_size": 1024,
+    "is_transformer": false,
+    "image_vocab_size": 16384,
     "frame_size": 16
   }
 }


### PR DESCRIPTION
Pre-trained vqgan weights can be downloaded from https://github.com/CompVis/taming-transformers

```
python3 preprocess.py --corpus_path corpora/cifar100_nolabel/cifar100_corpus.txt \
--dataset_path dataset.pt --tokenizer virtual --processes_num 8 --data_processor beit

python3 pretrain.py --dataset_path dataset.pt \
    --output_model_path models/beit.bin \
    --config_path models/beit/base_config.json \
    --tokenizer image \
    --vqgan_model_path vqgan.ckpt \
    --vqgan_config_path vqgan.yaml \
    --world_size 1 --gpu_ranks 0 \
    --total_steps 5000 --save_checkpoint_steps 1000 --batch_size 32


python3 finetune/run_image_classifier.py --pretrained_model_path models/beit_base.bin \
                                   --config_path models/beit/base_config.json \
                                   --train_path datasets/cifar10/train.tsv \
                                   --dev_path datasets/cifar10/test.tsv 

python3 inference/run_image_classifier_infer.py --load_model_path models/finetuned_model.bin \
                                   --config_path models/beit/base_config.json \
                                   --test_path datasets/cifar10/test.tsv \
                                   --prediction_path prediction.tsv \
                                   --labels_num 10

```