### PR TITLE
add support for pipeline parallelism

### DIFF
--- a/models/deepspeed_mp_config.json
+++ b/models/deepspeed_mp_config.json
@@ -1,0 +1,50 @@
+{
+  "gradient_accumulation_steps": 1,
+  "train_micro_batch_size_per_gpu":1,
+  "steps_per_print": 100,
+  "optimizer": {
+    "type": "Adam",
+    "params": {
+      "lr": 2e-5,
+      "weight_decay": 1e-2
+    }
+  },
+  "flops_profiler": {
+    "enabled": false,
+    "profile_step": 1,
+    "module_depth": -1,
+    "top_modules": 3,
+    "detailed": true
+  },
+  "fp16": {
+    "enabled": true,
+    "loss_scale": 0,
+    "loss_scale_window": 1000,
+    "hysteresis": 2,
+    "min_loss_scale": 1
+  },
+  "gradient_accumulation_dtype": "bf16",
+  "fp32_allreduce": true,
+  "data_types": {
+    "grad_accum_dtype":"fp32"
+  },
+  "zero_optimization": {
+    "stage": 1,
+    "offload_param": {
+      "device": "cpu",
+      "pin_memory": true
+    },
+    "offload_optimizer": {
+      "device": "cpu",
+      "pin_memory": true
+    }
+  },
+  "activation_checkpointing": {
+    "partition_activations": false,
+    "contiguous_memory_optimization": false,
+    "cpu_checkpointing": false
+  },
+  "wall_clock_breakdown": false,
+  "zero_allow_untested_optimizer": true,
+  "zero_force_ds_cpu_optimization": false
+}

--- a/scripts/convert_llama_from_3d_parallelism_checkpoint_to_pytorch_checkpoint.py
+++ b/scripts/convert_llama_from_3d_parallelism_checkpoint_to_pytorch_checkpoint.py
@@ -1,0 +1,78 @@
+import argparse
+import os
+import collections
+import torch
+
+
+parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+parser.add_argument("--input_model_path", type=str, default="models/input_model",
+                        help=".")
+parser.add_argument("--output_model_path", type=str, default="models/output_model.bin",
+                        help=".")
+parser.add_argument("--layers_num", type=int, default=32)
+parser.add_argument("--tensor_model_parallel_size", type=int, default=4)
+
+args = parser.parse_args()
+
+if not os.path.exists(args.output_model_path):
+    os.mkdir(args.output_model_path)
+
+model_piece_list = []
+for n in range(args.tensor_model_parallel_size):
+    model_piece = collections.OrderedDict()
+    model_index = str(n) if len(str(n))==2 else '0'+str(n)
+    for i in range(args.layers_num+2):
+        layer_index = str(i) if len(str(i))==2 else '0'+str(i)
+        weight_name = f"layer_{layer_index}-model_{model_index}-model_states.pt"
+        tmp_weight = torch.load(os.path.join(args.input_model_path, weight_name), map_location="cpu")
+        if i == 0:
+            model_piece["embedding.word.embedding.weight"] = tmp_weight["embeddings.word.embedding.weight"]
+        elif i == args.layers_num+1:
+            model_piece["target.lm.output_layer.weight"] = tmp_weight["target_layer.lm.output_layer.weight"]
+        else:
+            for j in range(3):
+                model_piece["encoder.transformer." + str(i-1) + ".self_attn.linear_layers."+ str(j) +".weight"] = tmp_weight["layer.self_attn.linear_layers."+ str(j) +".weight"]
+            model_piece["encoder.transformer." + str(i-1) + ".self_attn.final_linear.weight"] = tmp_weight["layer.self_attn.final_linear.weight"]
+            model_piece["encoder.transformer." + str(i-1) + ".feed_forward.linear_1.weight"] = tmp_weight["layer.feed_forward.linear_1.weight"]
+            model_piece["encoder.transformer." + str(i-1) + ".feed_forward.linear_2.weight"] = tmp_weight["layer.feed_forward.linear_2.weight"]
+            model_piece["encoder.transformer." + str(i-1) + ".feed_forward.linear_gate.weight"] = tmp_weight["layer.feed_forward.linear_gate.weight"]
+            model_piece["encoder.transformer." + str(i-1) + ".layer_norm_1.weight"] = tmp_weight["layer.layer_norm_1.weight"]
+            model_piece["encoder.transformer." + str(i-1) + ".layer_norm_2.weight"] = tmp_weight["layer.layer_norm_2.weight"]
+            if i == args.layers_num:
+                model_piece["encoder.layer_norm.weight"] = tmp_weight["layer_norm.weight"]
+    model_piece_list.append(model_piece)
+
+output_model = model_piece_list[0]
+
+for n in range(1, args.tensor_model_parallel_size):
+    model_piece = model_piece_list[n]
+    output_model["embedding.word.embedding.weight"] = torch.cat((output_model["embedding.word.embedding.weight"], model_piece["embedding.word.embedding.weight"]),dim=-2)
+    
+    for i in range(args.layers_num):
+        for j in range(3):
+            tensor_a=output_model["encoder.transformer." + str(i) + ".self_attn.linear_layers."+ str(j) +".weight"]
+            tensor_b=model_piece["encoder.transformer." + str(i) + ".self_attn.linear_layers."+ str(j) +".weight"]
+            output_model["encoder.transformer." + str(i) + ".self_attn.linear_layers."+ str(j) +".weight"]=torch.cat((tensor_a,tensor_b),dim=-2)
+        
+        tensor_a=output_model["encoder.transformer." + str(i) + ".self_attn.final_linear.weight"]
+        tensor_b=model_piece["encoder.transformer." + str(i) + ".self_attn.final_linear.weight"]
+      
+        output_model["encoder.transformer." + str(i) + ".self_attn.final_linear.weight"]=torch.cat((tensor_a,tensor_b),dim=-1)
+        
+        tensor_a=output_model["encoder.transformer." + str(i) + ".feed_forward.linear_1.weight"]
+        tensor_b=model_piece["encoder.transformer." + str(i) + ".feed_forward.linear_1.weight"]
+        output_model["encoder.transformer." + str(i) + ".feed_forward.linear_1.weight"]=torch.cat((tensor_a,tensor_b),dim=-2)
+        
+        tensor_a=output_model["encoder.transformer." + str(i) + ".feed_forward.linear_gate.weight"]
+        tensor_b=model_piece["encoder.transformer." + str(i) + ".feed_forward.linear_gate.weight"]
+        output_model["encoder.transformer." + str(i) + ".feed_forward.linear_gate.weight"]=torch.cat((tensor_a,tensor_b),dim=-2)
+                
+        tensor_a=output_model["encoder.transformer." + str(i) + ".feed_forward.linear_2.weight"]
+        tensor_b=model_piece["encoder.transformer." + str(i) + ".feed_forward.linear_2.weight"]
+        output_model["encoder.transformer." + str(i) + ".feed_forward.linear_2.weight"]=torch.cat((tensor_a,tensor_b),dim=-1)
+    
+    tensor_a=output_model["target.lm.output_layer.weight"]
+    tensor_b=model_piece["target.lm.output_layer.weight"]
+    output_model["target.lm.output_layer.weight"]=torch.cat((tensor_a,tensor_b),dim=-2)
+
+torch.save(output_model, args.output_model_path)

--- a/tencentpretrain/embeddings/embedding.py
+++ b/tencentpretrain/embeddings/embedding.py
@@ -32,3 +32,15 @@ class Embedding(nn.Module):
             emb = self.layer_norm(emb)
         emb = self.dropout(emb)
         return emb
+
+
+class EmbeddingPipe(torch.nn.Module):
+    def __init__(self, args,model):
+        super(EmbeddingPipe, self).__init__()
+        self.embeddings = model.embedding
+   
+    def forward(self, inputs):
+        src, seg = inputs
+        emb = self.embeddings(src, seg)
+
+        return emb, seg

--- a/tencentpretrain/embeddings/word_embedding.py
+++ b/tencentpretrain/embeddings/word_embedding.py
@@ -9,7 +9,7 @@ class WordEmbedding(nn.Module):
 
     def __init__(self, args, vocab_size):
         super(WordEmbedding, self).__init__()
-        if args.use_mp:
+        if args.tensor_model_parallel_size > 1:
             self.embedding = mpu.VocabParallelEmbedding(vocab_size, args.emb_size)
         else:
             self.embedding = nn.Embedding(vocab_size, args.emb_size)

--- a/tencentpretrain/initialize.py
+++ b/tencentpretrain/initialize.py
@@ -41,7 +41,7 @@ def init_env(args):
     if args.deepspeed:
         import deepspeed
         deepspeed.init_distributed(dist_backend=args.backend)
-        if args.use_mp:
+        if args.tensor_model_parallel_size > 1 or args.pipeline_model_parallel_size > 1:
             set_global_variables(args)
             args = get_args()
             finish_mpu_init()

--- a/tencentpretrain/opts.py
+++ b/tencentpretrain/opts.py
@@ -228,12 +228,8 @@ def deepspeed_opts(parser):
 
 
 def mp_opts(parser):
-    parser.add_argument("--use_mp", action="store_true",
-                        help=".")
     parser.add_argument("--tensor_model_parallel_size", type=int, default=1,
                         help="Degree of tensor model parallelism.")
-    parser.add_argument("--use_pipe", action="store_true",
-                        help=".")
     parser.add_argument("--pipeline_model_parallel_size", type=int, default=1,
                         help="Degree of pipeline model parallelism.")
     parser.add_argument("--virtual_pipeline_model_parallel_size", type=int, default=None,

--- a/tencentpretrain/targets/target.py
+++ b/tencentpretrain/targets/target.py
@@ -1,4 +1,7 @@
+import torch
 import torch.nn as nn
+
+from tencentpretrain import mpu
 
 
 class Target(nn.Module):
@@ -21,3 +24,26 @@ class Target(nn.Module):
                 self.loss_info = target(memory_bank, tgt, seg)
 
         return self.loss_info
+
+
+class TargetPipe(nn.Module):
+    def __init__(self,args,model):
+        super(TargetPipe, self).__init__()
+        self.target_layer=model.target
+    def forward(self,inputs):
+        hidden, seg=inputs
+        loss_info=self.target_layer(hidden, None, seg)
+        
+        return loss_info
+
+
+def CrossEntropy(outputs, labels):
+    output, loss_mask = outputs
+    tgt_lm, seg = labels[0], labels[1]
+    seg = seg.contiguous().view(-1)
+    tgt_lm = tgt_lm.contiguous().view(-1)
+    tgt_lm = tgt_lm[seg > loss_mask]
+    losses = mpu.vocab_parallel_cross_entropy(output, tgt_lm)
+    loss = torch.sum(losses.view(-1)) / len(losses)
+
+    return loss

--- a/tencentpretrain/trainer.py
+++ b/tencentpretrain/trainer.py
@@ -14,19 +14,22 @@ from tencentpretrain.utils.optimizers import *
 from tencentpretrain.utils import *
 from tencentpretrain.utils.seed import set_seed
 from tencentpretrain.initialize import *
+from tencentpretrain.embeddings.embedding import EmbeddingPipe
+from tencentpretrain.layers.transformer import ParallelTransformerLayerPipe
+from tencentpretrain.targets.target import TargetPipe, CrossEntropy
 
 
 def init_model(args):
     if args.deepspeed:
         import deepspeed
     
-        with deepspeed.zero.Init(data_parallel_group=mpu.get_data_parallel_group() if args.use_mp else None,
+        with deepspeed.zero.Init(data_parallel_group=mpu.get_data_parallel_group() if args.tensor_model_parallel_size > 1 else None,
                             remote_device=None,
                             config_dict_or_path=args.deepspeed_config,
                             enabled=args.enable_zero3 == True,
-                            mpu=mpu if args.use_mp else None ):
+                            mpu=mpu if args.tensor_model_parallel_size > 1 else None ):
             model_for_training = build_model(args)
-        if args.use_mp:
+        if args.tensor_model_parallel_size > 1 :
             for param in model_for_training.parameters():
                 mpu.set_defaults_if_not_set_tensor_model_parallel_attributes(param)
 
@@ -65,7 +68,7 @@ def init_model(args):
                     model_for_training = _load_state_dict_into_model(model_for_training, args.pretrained_model_path, "")
                     if args.lora_pretrained_model_path is not None:
                         model_for_training = _load_state_dict_into_model(model_for_training, args.lora_pretrained_model_path, "")
-        elif args.deepspeed and args.use_mp:
+        elif args.deepspeed and args.tensor_model_parallel_size > 1:
             model_for_training = load_mp_model(model_for_training, args.pretrained_model_path)
         else:
             model_for_training = load_model(model_for_training, args.pretrained_model_path,
@@ -184,33 +187,43 @@ class Trainer(object):
 
         raise NotImplementedError
 
+    def train_pipe(self, loader_iter, model):
+
+        raise NotImplementedError
+
     def train(self, args, local_rank, global_rank, loader, model, optimizer, scheduler):
         model.train()
         loader_iter = iter(loader)
+        if args.pipeline_model_parallel_size > 1:
+            self.seq_length = list(next(loader_iter))[0][0].size(1)
+            loader.start = 0
         while True:
             if self.current_step == self.total_steps + 1:
                 break
-            batch = list(next(loader_iter))
-            self.seq_length = batch[0].size(1)
-            if local_rank is not None:
-                for i in range(len(batch)):
-                    if torch.is_tensor(batch[i]):
-                        batch[i] = batch[i].cuda(local_rank)
-
-            loss = self.forward_propagation(batch, model)
-
-            if args.deepspeed:
-                model.backward(loss)
+            if args.pipeline_model_parallel_size > 1:
+                loss = self.train_pipe(loader_iter, model)
             else:
-                loss.backward()
+                batch = list(next(loader_iter))
+                self.seq_length = batch[0].size(1)
+                if local_rank is not None:
+                    for i in range(len(batch)):
+                        if torch.is_tensor(batch[i]):
+                            batch[i] = batch[i].cuda(local_rank)
 
-            if self.current_step % self.accumulation_steps == 0:
+                loss = self.forward_propagation(batch, model)
+
                 if args.deepspeed:
-                    model.step()
+                    model.backward(loss)
                 else:
-                    optimizer.step()
-                    scheduler.step()
-                    model.zero_grad()
+                    loss.backward()
+
+                if self.current_step % self.accumulation_steps == 0:
+                    if args.deepspeed:
+                        model.step()
+                    else:
+                        optimizer.step()
+                        scheduler.step()
+                        model.zero_grad()
 
             if self.current_step % self.report_steps == 0 and \
                     (not self.dist_train or (self.dist_train and global_rank == 0)):
@@ -338,6 +351,13 @@ class LmTrainer(Trainer):
         loss = model(src, tgt, seg)
 
         self.total_loss += loss.item()
+        loss = loss / self.accumulation_steps
+        return loss
+
+    def train_pipe(self, loader_iter, model):      
+        loss = model.train_batch(data_iter=loader_iter)
+        self.total_loss += loss.item()
+ 
         loss = loss / self.accumulation_steps
         return loss
 
@@ -676,6 +696,27 @@ def worker(local_rank, gpu_ranks, args):
     # Build model.
     model_for_training, model_for_dataloader = init_model(args)
 
+    if args.pipeline_model_parallel_size > 1:
+        from deepspeed.pipe import PipelineModule, TiedLayerSpec, LayerSpec
+        def get_model(model, args):
+            layers = [LayerSpec(EmbeddingPipe, args,model=model),
+                    *[LayerSpec(ParallelTransformerLayerPipe, args,model=model, layer_idx=idx) for idx in
+                        range(args.layers_num)],
+                    LayerSpec(TargetPipe, args=args,model=model)
+                    ]
+            return layers
+        layers = get_model(model_for_training,args)
+        from deepspeed.runtime.pipe.topology import PipeModelDataParallelTopology
+        topo = PipeModelDataParallelTopology(num_pp=mpu.get_pipeline_model_parallel_world_size(),
+                                             num_mp=mpu.get_tensor_model_parallel_world_size(),
+                                             num_dp=mpu.get_data_parallel_world_size())
+
+        model_for_training=PipelineModule(layers=layers, 
+                                          num_stages=args.pipeline_model_parallel_size, 
+                                          activation_checkpoint_interval=args.deepspeed_checkpoint_layers_num,
+                                          loss_fn=CrossEntropy,
+                                          checkpointable_layers=['ParallelTransformerLayerPipe'], topology=topo)
+
     # Build optimizer.
     custom_optimizer, custom_scheduler, optimizer_grouped_parameters = init_optimizer(args, model_for_training)
 
@@ -687,7 +728,7 @@ def worker(local_rank, gpu_ranks, args):
                                                     args=args,
                                                     optimizer=custom_optimizer,
                                                     lr_scheduler=custom_scheduler,
-                                                    mpu=mpu if args.use_mp else None,
+                                                    mpu=mpu if args.tensor_model_parallel_size > 1 and args.pipeline_model_parallel_size == 1 else None,
                                                     dist_init_required=False)
         if args.resume_from_checkpoint is not None:
             load_path, _ = model_for_training.load_checkpoint(
@@ -714,12 +755,9 @@ def worker(local_rank, gpu_ranks, args):
     if args.dist_train:
         if model_for_dataloader is not None:
             model_for_dataloader = model_for_dataloader.module
-        if args.use_mp:
-            train_loader = str2dataloader[args.data_processor](args, args.dataset_path, args.batch_size, global_rank,
-                                                               args.world_size // (args.tensor_model_parallel_size * args.pipeline_model_parallel_size),
-                                                               local_rank, True, model_for_dataloader)
-        else:
-            train_loader = str2dataloader[args.data_processor](args, args.dataset_path, args.batch_size, global_rank, args.world_size, local_rank, True, model_for_dataloader)
+        train_loader = str2dataloader[args.data_processor](args, args.dataset_path, args.batch_size, global_rank,
+                                                           args.world_size // (args.tensor_model_parallel_size * args.pipeline_model_parallel_size),
+                                                           local_rank, True, model_for_dataloader)
     else:
         train_loader = str2dataloader[args.data_processor](args, args.dataset_path, args.batch_size, 0, 1, local_rank, True, model_for_dataloader)
 

--- a/tencentpretrain/trainer.py
+++ b/tencentpretrain/trainer.py
@@ -57,17 +57,17 @@ def init_model(args):
     
         if args.deepspeed and args.enable_zero3:
             if os.path.isdir(args.pretrained_model_path):
-                    index_filename = os.path.join(args.pretrained_model_path, "tencentpretrain_model.bin.index.json")
-                    with open(index_filename, "r") as f:
-                        index = json.loads(f.read())
-                    shard_filenames = sorted(set(index["weight_map"].values()))
-                    shard_filenames = [os.path.join(args.pretrained_model_path, f) for f in shard_filenames]
-                    for shard_file in shard_filenames:
-                        model_for_training = _load_state_dict_into_model(model_for_training, shard_file, "")
+                index_filename = os.path.join(args.pretrained_model_path, "tencentpretrain_model.bin.index.json")
+                with open(index_filename, "r") as f:
+                    index = json.loads(f.read())
+                shard_filenames = sorted(set(index["weight_map"].values()))
+                shard_filenames = [os.path.join(args.pretrained_model_path, f) for f in shard_filenames]
+                for shard_file in shard_filenames:
+                    model_for_training = _load_state_dict_into_model(model_for_training, shard_file, "")
             else:
-                    model_for_training = _load_state_dict_into_model(model_for_training, args.pretrained_model_path, "")
-                    if args.lora_pretrained_model_path is not None:
-                        model_for_training = _load_state_dict_into_model(model_for_training, args.lora_pretrained_model_path, "")
+                model_for_training = _load_state_dict_into_model(model_for_training, args.pretrained_model_path, "")
+                if args.lora_pretrained_model_path is not None:
+                    model_for_training = _load_state_dict_into_model(model_for_training, args.lora_pretrained_model_path, "")
         elif args.deepspeed and args.tensor_model_parallel_size > 1:
             model_for_training = load_mp_model(model_for_training, args.pretrained_model_path)
         else:

--- a/tencentpretrain/utils/dataloader.py
+++ b/tencentpretrain/utils/dataloader.py
@@ -44,8 +44,6 @@ class Dataloader(object):
             # Reach file end.
             self.dataset_reader.seek(0)
 
-        if self.shuffle:
-            random.shuffle(self.buffer)
         self.start = 0
         self.end = len(self.buffer)
 

--- a/tencentpretrain/utils/dataloader.py
+++ b/tencentpretrain/utils/dataloader.py
@@ -28,6 +28,7 @@ class Dataloader(object):
         self.span_masking = args.span_masking
         self.span_geo_prob = args.span_geo_prob
         self.span_max_length = args.span_max_length
+        self.pipeline_model_parallel_size = args.pipeline_model_parallel_size
 
     def _fill_buf(self):
         try:
@@ -183,10 +184,14 @@ class LmDataloader(Dataloader):
                 src.append(src_single[:-1])
                 tgt.append(src_single[1:])
                 seg.append([1] * ins[1][0] + [0] * (len(src_single) - 1 - ins[1][0]))
-
-            yield torch.LongTensor(src), \
-                torch.LongTensor(tgt), \
-                torch.LongTensor(seg)
+            
+            if self.pipeline_model_parallel_size > 1:
+                yield (torch.LongTensor(src),torch.LongTensor(seg)), \
+                    (torch.LongTensor(tgt),torch.LongTensor(seg))
+            else:
+                yield torch.LongTensor(src), \
+                    torch.LongTensor(tgt), \
+                    torch.LongTensor(seg)
 
 
 class BilmDataloader(Dataloader):


### PR DESCRIPTION
TencentPretrain支持通过deepspeed托管使用模型并行,可以单独使用张量并行或流水线并行，也可以一起使用
通过参数tensor_model_parallel_size指定张量并行组数量，默认值为1，代表不使用张量并行
通过参数pipeline_model_parallel_size指定流水线并行组数量，默认值为1，代表不使用流水线并行

例如此处指定了张量并行组数量为2，不使用流水线并行，gpu数量为8

运行指令参考:
deepspeed pretrain.py --deepspeed --deepspeed_config models/deepspeed_mp_config.json 
--dataset_path dataset_path.pt
--spm_model_path sentencepiece.model 
--config_path models/llama/7b_config.json 
--output_model_path models/llama --scheduler cosine --warmup 0.03 
--world_size 8 --learning_rate 5e-5 --deepspeed_checkpoint_activations 
--data_processor lm --total_steps 100000 
--save_checkpoint_steps 10000 --batch_size 4 
--report_steps 50 --tensor_model_parallel_size 2 
--pretrained_model_path models/input_model

例如此处指定了张量并行组数量为2，流水线并行组数量为2，gpu数量为8

运行指令参考:
deepspeed pretrain.py --deepspeed --deepspeed_config models/deepspeed_mp_config.json 
--dataset_path dataset_path.pt
--spm_model_path sentencepiece.model 
--config_path models/llama/7b_config.json 
--output_model_path models/llama --scheduler cosine --warmup 0.03 
--world_size 8 --learning_rate 5e-5 --deepspeed_checkpoint_activations 
--data_processor lm --total_steps 100000 
--save_checkpoint_steps 10000 --batch_size 4 
--report_steps 50 --tensor_model_parallel_size 2  --pipeline_model_parallel_size 2
--pretrained_model_path models/input_model

训练完成后使用转换脚本scripts/convert_llama_from_3d_parallelism_checkpoint_to_pytorch_checkpoint.py可以将权重转换为pytorch格式，使用时需要指定张量并行组数量和模型层数（transformer layer数量）

若张量并行组数量为2，模型层数为32层，运行指令参考:
python3 scripts/convert_llama_from_3d_parallelism_checkpoint_to_pytorch_checkpoint.py 
--input_model_path models/llama
--output_model_path models/output_model.bin
--tensor_model_parallel_size 2
--layers_num 32
