### PR TITLE
修复ELMO预训练中bilm_target.py的seg参数缺失问题

### DIFF
--- a/tencentpretrain/targets/bilm_target.py
+++ b/tencentpretrain/targets/bilm_target.py
@@ -26,9 +26,9 @@ class BilmTarget(LmTarget):
         tgt_forward, tgt_backward = tgt[0], tgt[1]
         # Forward.
         loss_forward, correct_forward, _ = \
-            self.lm(memory_bank[:, :, :self.hidden_size], tgt_forward)
+            self.lm(memory_bank[:, :, :self.hidden_size], tgt_forward, seg)
         # Backward.
         loss_backward, correct_backward, denominator_backward = \
-            self.lm(memory_bank[:, :, self.hidden_size:], tgt_backward)
+            self.lm(memory_bank[:, :, self.hidden_size:], tgt_backward, seg)
 
         return loss_forward, loss_backward, correct_forward, correct_backward, denominator_backward


### PR DESCRIPTION
在预训练ELMO模型时，我发现`bilm_target.py`中的前向传播和后向传播函数调用缺少了`seg`参数传递，这导致了预训练过程中的运行时错误：TypeError: LmTarget.lm() missing 1 required positional argument: 'seg'


此PR修复了这个问题，通过在相关函数调用中加入`seg`参数。这样可以确保在进行前向和后向传播时正确地传递所有必需的参数，从而避免上述类型错误。

**具体更改：**
- 在调用`self.lm()`方法时添加了缺失的`seg`参数。

**测试情况：**
- 已经在我的开发环境中进行了基本的功能测试，预训练过程现在能够正常执行而不再抛出错误。

请审查这些更改，感谢您的时间和努力！