### PR TITLE
Fix the bug that checkpoint saving.

### DIFF
--- a/tencentpretrain/trainer.py
+++ b/tencentpretrain/trainer.py
@@ -245,15 +245,15 @@ class Trainer(object):
 
             self.current_step += 1
 
-        if self.current_step - 1 % self.save_checkpoint_steps != 0: 
+        if self.total_steps % self.save_checkpoint_steps != 0: 
             if args.deepspeed:
                 if args.use_lora:
                     if global_rank == 0:
-                        save_model(model, self.output_model_path + "-" + str(self.current_step - 1), args.use_lora)
+                        save_model(model, self.output_model_path + "-" + str(self.total_steps), args.use_lora)
                 else:
-                    model.save_checkpoint(self.output_model_path, str(self.current_step - 1))
+                    model.save_checkpoint(self.output_model_path, str(self.total_steps))
             else:
-                save_model(model, self.output_model_path + "-" + str(self.current_step - 1), args.use_lora)
+                save_model(model, self.output_model_path + "-" + str(self.total_steps), args.use_lora)
 
 
 class MlmTrainer(Trainer):

--- a/tencentpretrain/trainer.py
+++ b/tencentpretrain/trainer.py
@@ -245,6 +245,16 @@ class Trainer(object):
 
             self.current_step += 1
 
+        if self.current_step - 1 % self.save_checkpoint_steps != 0: 
+            if args.deepspeed:
+                if args.use_lora:
+                    if global_rank == 0:
+                        save_model(model, self.output_model_path + "-" + str(self.current_step - 1), args.use_lora)
+                else:
+                    model.save_checkpoint(self.output_model_path, str(self.current_step - 1))
+            else:
+                save_model(model, self.output_model_path + "-" + str(self.current_step - 1), args.use_lora)
+
 
 class MlmTrainer(Trainer):
     def __init__(self, args):


### PR DESCRIPTION
Fix the bug that the final checkpoint will not be saved when the total steps cannot be divided evenly by save_checkpoint_steps.
Since the number of total steps needs to be manually calculated and set according to the number of epochs, the sample size, the batch size and the number of workers, it is highly likely that the value of steps is not a perfect integer and may not meet the requirements for saving all checkpoints. Therefore, this fix is necessary.